### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -18,7 +18,7 @@
     ],
     "sharedGlobals": []
   },
-  "nxCloudAccessToken": "MTMxZDExNzMtMTE4ZC00MjE5LWJjY2MtZWQ2NDAyZDAzY2FjfHJlYWQtd3JpdGU=",
+  "nxCloudAccessToken": "ZTA0YWRlODktZTFhMS00ZTExLTk5MzktNmE3NzMyNWM2Yjg4fHJlYWQtd3JpdGU=",
   "targetDefaults": {
     "@angular-devkit/build-angular:browser": {
       "cache": true,
@@ -37,15 +37,8 @@
     "@nx/jest:jest": {
       "cache": true,
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
-      "options": {
-        "passWithNoTests": true
-      },
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true
-        }
-      }
+      "options": { "passWithNoTests": true },
+      "configurations": { "ci": { "ci": true, "codeCoverage": true } }
     }
   },
   "plugins": [
@@ -58,12 +51,7 @@
         "ciTargetName": "e2e-ci"
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     {
       "plugin": "@nx/webpack/plugin",
       "options": {


### PR DESCRIPTION
### **User description**
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/66a66f206b510dce11eafc54/workspaces/66a66f40ced40352f1ccfd9f

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Set up Nx Cloud for the Nx workspace, enabling distributed caching and GitHub integration for faster CI and improved developer experience.
- Updated `nxCloudAccessToken` to a new value.
- Refactored `targetDefaults` for `@nx/jest:jest` to a more compact JSON format.
- Refactored plugin configurations for `@nx/eslint/plugin` and `@nx/webpack/plugin` to a more compact JSON format.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nx.json</strong><dd><code>Setup Nx Cloud and refactor configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nx.json

<li>Updated <code>nxCloudAccessToken</code> value.<br> <li> Refactored <code>targetDefaults</code> for <code>@nx/jest:jest</code> to a more compact format.<br> <li> Refactored plugin configurations for <code>@nx/eslint/plugin</code> and <br><code>@nx/webpack/plugin</code> to a more compact format.<br>


</details>


  </td>
  <td><a href="https://github.com/TheJordach/nx-mortgage-full-stack/pull/2/files#diff-15552e50b1b7c05b05b7ffe08ee47b5ed62b8d2039229c58972a42fd22a7381c">+4/-16</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

